### PR TITLE
fix(workflows): pin setup-firefox action to full commit SHA (v1.7.0)

### DIFF
--- a/.github/workflows/ui_cross_browser_test.yml
+++ b/.github/workflows/ui_cross_browser_test.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Set up Firefox and GeckoDriver
         if: matrix.browser == 'firefox'
-        uses: browser-actions/setup-firefox@latest
+        uses: browser-actions/setup-firefox@5914774dda97099441f02628f8d46411fcfbd208 # v1.7.0
 
       - name: Clone the test repository
         run: |


### PR DESCRIPTION
Replaced mutable tag (@latest) with immutable commit SHA 5914774dda97099441f02628f8d46411fcfbd208 for browser-actions/setup-firefox (v1.7.0).

Fixes SonarQube Security Hotspot (githubactions:S7637) by avoiding mutable tags.