### PR TITLE
chore: Add Cursor automations for auto-PR and CI babysit merge

### DIFF
--- a/.cursor/automations/auto-open-pr.workflow.json
+++ b/.cursor/automations/auto-open-pr.workflow.json
@@ -1,0 +1,30 @@
+{
+  "name": "Auto-open PR on push",
+  "description": "Opens a PR to main when work is pushed to a feature branch without an existing open PR.",
+  "workflow": {
+    "triggers": [
+      {
+        "git": {
+          "push": {
+            "repos": ["serhatozdursun/resume"]
+          }
+        }
+      }
+    ],
+    "actions": [{ "gitPr": {} }],
+    "prompts": [
+      {
+        "prompt": "You are automating PR creation for serhatozdursun/resume (personal portfolio site).\n\nTRIGGER: A push event fired on this repository.\n\nRULES:\n1. If the pushed branch is `main`, stop immediately — do nothing.\n2. Check whether an open PR already exists from this branch to `main`. If one exists, stop — do nothing.\n3. Otherwise, open a new PR targeting `main`.\n\nPR CONTENT:\n- Title: concise summary from branch name and latest commit message.\n- Body: 2–4 bullet points summarizing changes from commit messages.\n- Open as a ready PR (not draft).\n\nAfter opening, comment: \"PR opened by automation. CI babysit + auto-merge will run when checks complete.\"\n\nDo not modify code — only create the PR."
+      }
+    ],
+    "model": "",
+    "gitConfig": {
+      "repo": "serhatozdursun/resume",
+      "branch": "main"
+    },
+    "agentOptions": {
+      "skipInstall": false
+    },
+    "memoryEnabled": false
+  }
+}

--- a/.cursor/automations/ci-babysit-auto-merge.workflow.json
+++ b/.cursor/automations/ci-babysit-auto-merge.workflow.json
@@ -1,0 +1,30 @@
+{
+  "name": "CI fix loop + auto-merge",
+  "description": "On CI completion for a PR: fix failing checks (tests, SonarCloud, Danger, browser e2e), push fixes, and squash-merge when all required checks pass.",
+  "workflow": {
+    "triggers": [
+      {
+        "git": {
+          "ciCompleted": {
+            "repos": ["serhatozdursun/resume"]
+          }
+        }
+      }
+    ],
+    "actions": [{ "gitPr": {} }, { "prComment": {} }, { "manageCheckRun": {} }],
+    "prompts": [
+      {
+        "prompt": "You babysit PRs on serhatozdursun/resume until merge-ready, then auto-merge. Read and follow the project skill at `.cursor/skills/babysit-pr/SKILL.md`.\n\nTRIGGER: CI checks completed on a pull request.\n\nIF ALL REQUIRED CHECKS PASSED:\n- Required: test-and-analyze, Analyze (javascript), Analyze (typescript), browser_e2e_tests (chrome), browser_e2e_tests (firefox)\n- If the PR is mergeable and all five are green, run: `gh pr merge --squash --delete-branch`\n- Comment confirming auto-merge. Stop.\n\nIF ANY REQUIRED CHECK FAILED OR IS STILL PENDING:\n- Track fix attempt count (max 5 per PR). If at limit, comment with blockers and stop.\n- Read failed check logs only as needed.\n- Apply scoped fixes per the babysit-pr skill.\n- Run `yarn test --coverage`, `yarn lint`, `yarn build` before pushing.\n- Push and stop — the next CI completion will re-trigger this automation.\n\nNever weaken CI, skip tests, or merge with failing checks."
+      }
+    ],
+    "model": "",
+    "gitConfig": {
+      "repo": "serhatozdursun/resume",
+      "branch": "main"
+    },
+    "agentOptions": {
+      "skipInstall": false
+    },
+    "memoryEnabled": false
+  }
+}

--- a/.cursor/skills/babysit-pr/SKILL.md
+++ b/.cursor/skills/babysit-pr/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: babysit-pr
+description: >-
+  Keep a PR merge-ready on serhatozdursun/resume: triage CI failures (tests,
+  SonarCloud, Danger, browser e2e), push scoped fixes, and squash-merge when
+  all required checks pass. Use for CI babysit automations and manual agent runs.
+---
+
+# Babysit PR — serhatozdursun/resume
+
+Personal playground repo. Goal: get the PR green and **squash-merge to main** without human approval.
+
+## Required checks (all must pass before merge)
+
+1. `test-and-analyze` — Jest coverage, SonarCloud scan, Danger AI review
+2. `Analyze (javascript)` — SonarCloud
+3. `Analyze (typescript)` — SonarCloud
+4. `browser_e2e_tests (chrome)` — Selenium UI tests
+5. `browser_e2e_tests (firefox)` — Selenium UI tests
+
+## Workflow
+
+1. Identify the PR branch from the trigger context.
+2. Fetch failed check runs (`gh pr checks`, `gh run view --log-failed`). Read only failure summaries and relevant log sections — not full JSON dumps.
+3. Fix issues **in this PR's scope only**:
+   - **Coverage** below 80% per changed file (`MIN_FILE_COVERAGE` in `dangerfile.ts`) → add targeted tests under `src/tests/`
+   - **SonarCloud** quality gate → fix smells, duplication, uncovered lines in `src/`
+   - **Danger** blockers → address valid findings only
+   - **Lint / build** → `yarn lint`, `yarn build`
+   - **Browser e2e** → fix UI regressions; do not disable tests or workflows
+4. Before pushing, run locally:
+   ```bash
+   yarn test --coverage
+   yarn lint
+   yarn build
+   ```
+5. Commit with a clear message, push to the PR branch, and wait for CI.
+6. Repeat until all five required checks pass **or** 5 fix attempts are exhausted.
+
+## Merge (when all checks green)
+
+```bash
+gh pr merge --squash --delete-branch
+```
+
+Post a PR comment summarizing fixes and confirming auto-merge.
+
+## Hard stops — do NOT
+
+- Modify `.github/workflows/` or CI config to make failures pass
+- Lower Sonar/coverage thresholds
+- Skip or delete tests
+- Merge while any required check is failing or pending
+- Make unrelated refactors
+
+## If stuck after 5 attempts
+
+Comment on the PR with: what failed, what was tried, and what needs human input. Do not merge.


### PR DESCRIPTION
## Summary
- Adds prefilled Cursor Automation workflow configs (auto-open PR on push, CI fix loop + auto-merge)
- Adds `babysit-pr` project skill with repo-specific quality-gate and merge rules

## Test plan
- [ ] Create both automations in Cursor dashboard from `.cursor/automations/*.workflow.json`
- [ ] Enable Cloud Agents compute
- [ ] Push a test branch (e.g. `playground/auto-pr-test`) and verify PR opens + CI babysit runs

Made with [Cursor](https://cursor.com)